### PR TITLE
feat: add ability to send screenshot when loot logger is triggered

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.23'
+def runeLiteVersion = '1.6.25'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -17,6 +17,15 @@ public interface DiscordLootLoggerConfig extends Config
 	String webhook();
 
 	@ConfigItem(
+			keyName = "sendScreenshot",
+			name = "Send Screenshot",
+			description = "Option to include a screenshot of the game client when receiving the loot."
+	)
+	default boolean sendScreenshot() {
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "lootnpcs",
 		name = "Loot NPCs",
 		description = "Only logs loot from these NPCs, comma separated"

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -188,9 +188,12 @@ public class DiscordLootLoggerPlugin extends Plugin
 				.setType(MultipartBody.FORM)
 				.addFormDataPart("payload_json", GSON.toJson(webhookBody));
 
-		if (config.sendScreenshot()) {
+		if (config.sendScreenshot())
+		{
 			sendWebhookWithScreenshot(url, requestBodyBuilder);
-		} else {
+		}
+		else
+		{
 			buildRequestAndSend(url, requestBodyBuilder);
 		}
 	}
@@ -199,9 +202,11 @@ public class DiscordLootLoggerPlugin extends Plugin
 		drawManager.requestNextFrameListener(image -> {
 			BufferedImage bufferedImage = (BufferedImage) image;
 			byte[] imageBytes;
-			try {
+			try
+			{
 				imageBytes = convertImageToByteArray(bufferedImage);
-			} catch (IOException e) {
+			} catch (IOException e)
+			{
 				log.debug("Error converting image to byte array");
 				return;
 			}

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -172,7 +172,8 @@ public class DiscordLootLoggerPlugin extends Plugin
         }
 	}
 
-    private void sendWebhooks(WebhookBody webhookBody) {
+    private void sendWebhooks(WebhookBody webhookBody)
+	{
         String configUrl = config.webhook();
         if (Strings.isNullOrEmpty(configUrl))
         {
@@ -198,7 +199,8 @@ public class DiscordLootLoggerPlugin extends Plugin
 		}
 	}
 
-	private void sendWebhookWithScreenshot(HttpUrl url, MultipartBody.Builder requestBodyBuilder) {
+	private void sendWebhookWithScreenshot(HttpUrl url, MultipartBody.Builder requestBodyBuilder)
+	{
 		drawManager.requestNextFrameListener(image -> {
 			BufferedImage bufferedImage = (BufferedImage) image;
 			byte[] imageBytes;
@@ -217,7 +219,8 @@ public class DiscordLootLoggerPlugin extends Plugin
 		});
 	}
 
-	private void buildRequestAndSend(HttpUrl url, MultipartBody.Builder requestBodyBuilder) {
+	private void buildRequestAndSend(HttpUrl url, MultipartBody.Builder requestBodyBuilder)
+	{
 		RequestBody requestBody = requestBodyBuilder.build();
 		Request request = new Request.Builder()
 				.url(url)
@@ -227,7 +230,8 @@ public class DiscordLootLoggerPlugin extends Plugin
 	}
 
 
-	private byte[] convertImageToByteArray(BufferedImage bufferedImage) throws IOException {
+	private byte[] convertImageToByteArray(BufferedImage bufferedImage) throws IOException
+	{
 		byte[] imageBytes;
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         ImageIO.write(bufferedImage, "png", byteArrayOutputStream);


### PR DESCRIPTION
adds the ability for a user to be able to send a screenshot with the loot. It sends two separate web requests (one for the loot and one for the screenshot).