### PR TITLE
feat: bold the npc name and add the option to only log high value ite…

### DIFF
--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -36,7 +36,7 @@ public interface DiscordLootLoggerConfig extends Config
 	@ConfigItem(
 		keyName = "includeLowValueItems",
 		name = "Include Low Value Items",
-		description = "Only logs loot items worth more than the value set in loot value option."
+		description = "Only log loot items worth more than the value set in loot value option."
 	)
 	default boolean includeLowValueItems()
 	{

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -34,6 +34,16 @@ public interface DiscordLootLoggerConfig extends Config
 	String lootNpcs();
 
 	@ConfigItem(
+		keyName = "includeLowValueItems",
+		name = "Include Low Value Items",
+		description = "Only logs loot items worth more than the value set in loot value option."
+	)
+	default boolean includeLowValueItems()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "lootvalue",
 		name = "Loot Value",
 		description = "Only logs loot worth more then the given value. 0 to disable."

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -159,9 +159,9 @@ public class DiscordLootLoggerPlugin extends Plugin
 
 			totalValue += total;
 
-			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			if (config.includeLowValueItems() || total >= targetValue)
 			{
+				ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 				stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append("\n");
 				webhookBody.getEmbeds().add(new WebhookBody.Embed(new WebhookBody.UrlEmbed(itemImageUrl(itemId))));
 			}

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -147,7 +147,8 @@ public class DiscordLootLoggerPlugin extends Plugin
 
 		long totalValue = 0;
 		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append(name).append(":\n");
+		stringBuilder.append("**").append(name).append("**").append(":\n");
+		final int targetValue = config.lootValue();
 		for (ItemStack item : stack(items))
 		{
 			int itemId = item.getId();
@@ -159,11 +160,13 @@ public class DiscordLootLoggerPlugin extends Plugin
 			totalValue += total;
 
 			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-			stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append("\n");
-			webhookBody.getEmbeds().add(new WebhookBody.Embed(new WebhookBody.UrlEmbed(itemImageUrl(itemId))));
+			if (config.includeLowValueItems() || total >= targetValue)
+			{
+				stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append("\n");
+				webhookBody.getEmbeds().add(new WebhookBody.Embed(new WebhookBody.UrlEmbed(itemImageUrl(itemId))));
+			}
 		}
 
-		final int targetValue = config.lootValue();
 		if (targetValue == 0 || totalValue >= targetValue)
 		{
 			webhookBody.setContent(stringBuilder.toString());


### PR DESCRIPTION
…ms, ignoring low value ones
![Annotation 2020-08-27 135822](https://user-images.githubusercontent.com/10621463/91478493-f8b65680-e86d-11ea-9af1-6a00f40dcfd4.png)

For example, in the second entry here the drop was a few coins, but I chose to ignore the coins and only log the bones because the bones were greater than the 50gp loot value I had configured.
