### PR TITLE
Included stack value option

### DIFF
--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -52,4 +52,14 @@ public interface DiscordLootLoggerConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "stackvalue",
+		name = "Include Stack Value",
+		description = "Include the value of each stack."
+	)
+	default boolean stackValue()
+	{
+		return true;
+	}
 }

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -26,6 +26,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.loottracker.LootReceived;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.util.ImageCapture;
+import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
 import net.runelite.client.util.WildcardMatcher;
 import static net.runelite.http.api.RuneLiteAPI.GSON;
@@ -157,7 +158,14 @@ public class DiscordLootLoggerPlugin extends Plugin
 			if (config.includeLowValueItems() || total >= targetValue)
 			{
 				ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-				stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append("\n");
+				if (config.stackValue())
+				{
+					stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append(" (").append(QuantityFormatter.quantityToStackSize(total)).append(")").append("\n");
+				}
+				else
+				{
+					stringBuilder.append(qty).append(" x ").append(itemComposition.getName()).append("\n");
+				}
 				webhookBody.getEmbeds().add(new WebhookBody.Embed(new WebhookBody.UrlEmbed(itemImageUrl(itemId))));
 			}
 		}


### PR DESCRIPTION
This adds an additional config option, to also include the stack value in the post.

Examples:

`1x Granite maul (113k)`

`2x Granite maul (226k)`