### PR TITLE
Use varp to detect full pouches in bank interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,12 @@ plugins {
 repositories {
 	mavenLocal()
 	maven {
-		url = 'http://repo.runelite.net'
+		url = 'https://repo.runelite.net'
 	}
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.18.1'
+def runeLiteVersion = '1.7.8.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -19,16 +19,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
 	testImplementation 'junit:junit:4.12'
-	testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
-		exclude group: 'ch.qos.logback', module: 'logback-classic'
-	}
+	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 	testImplementation 'org.mockito:mockito-all:1.10.19'
 	testImplementation 'com.google.inject.extensions:guice-testlib:4.1.0'
 }
 
 group = 'info.sigterm.plugins.esspouch'
-version = '1.3'
+version = '1.4'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/info/sigterm/plugins/esspouch/Pouch.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/Pouch.java
@@ -32,13 +32,16 @@ import net.runelite.api.ItemID;
 
 enum Pouch
 {
-	SMALL(3),
-	MEDIUM(6, 3),
-	LARGE(9, 7),
-	GIANT(12, 9);
+	SMALL(3, -1, 1),
+	MEDIUM(6, 3, 2),
+	LARGE(9, 7, 4),
+	GIANT(12, 9, 8);
 
 	private final int baseHoldAmount;
 	private final int degradedBaseHoldAmount;
+	
+	@Getter(AccessLevel.PACKAGE)
+	private final int bankVarpFlag;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -49,15 +52,11 @@ enum Pouch
 	@Setter(AccessLevel.PACKAGE)
 	private boolean unknown = true;
 
-	Pouch(int holdAmount)
-	{
-		this(holdAmount, -1);
-	}
-
-	Pouch(int holdAmount, int degradedHoldAmount)
+	Pouch(int holdAmount, int degradedHoldAmount, int bankVarpFlag)
 	{
 		this.baseHoldAmount = holdAmount;
 		this.degradedBaseHoldAmount = degradedHoldAmount;
+		this.bankVarpFlag = bankVarpFlag;
 	}
 
 	int getHoldAmount()


### PR DESCRIPTION
When both the player inventory and an essence pouch's contents are updated in the same tick, the plugin sometimes does not recognize the change in the essence pouch, since it can't see the essence leave the inventory. This is most noticeable when filling an essence pouch on the same tick as withdrawing from the bank.

This PR adds functionality to detect full essence pouches while the bank is open using VarPlayer 261. It is a 4-bit field, with each bit controlling whether to show "Fill" or "Empty" in the minimenu for each essence pouch.

Thanks to @Hydrox6 for the pointer on the varp bit field.

Without the fix:
![esspouch-without-bank-fix](https://user-images.githubusercontent.com/1868974/119048061-b3523000-b98c-11eb-87e6-1f3b2cc5fae7.gif)

With the fix:
![esspouch-with-bank-fix](https://user-images.githubusercontent.com/1868974/119048085-b9e0a780-b98c-11eb-9606-ec3bb8a254d4.gif)
