### PR TITLE
Add option to include player's username in posted Discord message

### DIFF
--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -62,4 +62,15 @@ public interface DiscordLootLoggerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "includeusername",
+		name = "Include Username",
+		description = "Include your RSN in the post."
+	)
+	default boolean includeUsername()
+	{
+		return false;
+	}
+
 }

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -12,6 +12,7 @@ import java.util.List;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.NPC;
 import net.runelite.client.config.ConfigManager;
@@ -68,6 +69,9 @@ public class DiscordLootLoggerPlugin extends Plugin
 	{
 		return "https://static.runelite.net/cache/item/icon/" + itemId + ".png";
 	}
+
+	@Inject
+	private Client client;
 
 	@Override
 	protected void startUp()
@@ -137,6 +141,11 @@ public class DiscordLootLoggerPlugin extends Plugin
 		processLoot(lootReceived.getName(), lootReceived.getItems());
 	}
 
+	private String getPlayerName()
+	{
+		return client.getLocalPlayer().getName();
+	}
+
 	private void processLoot(String name, Collection<ItemStack> items)
 	{
 		WebhookBody webhookBody = new WebhookBody();
@@ -144,7 +153,11 @@ public class DiscordLootLoggerPlugin extends Plugin
 		boolean sendMessage = false;
 		long totalValue = 0;
 		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append("**").append(name).append("**").append(":\n");
+		if (config.includeUsername())
+		{
+			stringBuilder.append("\n**").append(getPlayerName()).append("**").append(":\n\n");
+		}
+		stringBuilder.append("***").append(name).append("***").append(":\n");
 		final int targetValue = config.lootValue();
 		for (ItemStack item : stack(items))
 		{
@@ -160,7 +173,7 @@ public class DiscordLootLoggerPlugin extends Plugin
 			{
 				sendMessage = true;
 				ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-				stringBuilder.append(qty).append(" x ").append(itemComposition.getName());
+				stringBuilder.append("*").append(qty).append(" x ").append(itemComposition.getName()).append("*");
 				if (config.stackValue())
 				{
 					stringBuilder.append(" (").append(QuantityFormatter.quantityToStackSize(total)).append(")");


### PR DESCRIPTION
Adds option for the player to include their username in the screenshot. If the player previously had the chat closed in resizeable mode, there was no way to indicate who received the drop if they were not using the Player Indicator plugin also.

NPC name and Items dropped now in italics in the Discord message, and the Player Name in bold, to allow for easy differentiation between NPC/Item data and the Player data.

# Before

![image](https://user-images.githubusercontent.com/71386629/121781398-6bde4e80-cb9c-11eb-8e41-903a40d18240.png)

![image](https://user-images.githubusercontent.com/71386629/121781452-b3fd7100-cb9c-11eb-8e2d-39692375e984.png)

# After

![image](https://user-images.githubusercontent.com/71386629/121781479-e4dda600-cb9c-11eb-9c73-124ffc9e58f0.png)

![image](https://user-images.githubusercontent.com/71386629/121781486-ead38700-cb9c-11eb-9b2f-7b1b7eaf3da7.png)
