### PR TITLE
Add support for Clan Drop Notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.35'
+def runeLiteVersion = '1.7.22'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerConfig.java
@@ -3,6 +3,7 @@ package info.sigterm.plugins.discordlootlogger;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(DiscordLootLoggerConfig.GROUP)
 public interface DiscordLootLoggerConfig extends Config
@@ -72,5 +73,52 @@ public interface DiscordLootLoggerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigSection(
+			name="Clan Drop Notifications",
+			description = "Settings for clan drop notifications",
+			position = 2
+	)
+
+	String clanDropNotifications = "Clan Drop Notifications";
+
+	@ConfigItem(
+			keyName = "enableClanDrops",
+			name = "Enable Clan Drops",
+			description = "Enable this if you want to automatically post a screenshot when you receive a clan drop",
+			position = 1,
+			section = clanDropNotifications
+	)
+
+	default boolean enableClanDrops() {
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "autoMessageEnabled",
+			name = "Enable auto message",
+			description = "Enables an auto message in the chatbox",
+			section = clanDropNotifications,
+			position = 2
+	)
+	default boolean autoMessageEnabled() {return false;}
+
+	@ConfigItem(
+			keyName = "autoMessageDate",
+			name = "Enable date post",
+			description = "Enables automatic date posting in the chat",
+			section = clanDropNotifications,
+			position = 3
+	)
+	default boolean autoMessageDate() {return false;}
+
+	@ConfigItem(
+			keyName = "autoMessage",
+			name = "Auto Message",
+			description = "The auto message to type",
+			section = clanDropNotifications,
+			position = 4)
+	default String autoMessage() {return "";}
+
 
 }

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -5,16 +5,20 @@ import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.net.URL;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
+import javax.net.ssl.HttpsURLConnection;
+
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.NPC;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -69,6 +73,7 @@ public class DiscordLootLoggerPlugin extends Plugin
 	{
 		return "https://static.runelite.net/cache/item/icon/" + itemId + ".png";
 	}
+	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
 	@Inject
 	private Client client;
@@ -97,6 +102,15 @@ public class DiscordLootLoggerPlugin extends Plugin
 		{
 			String s = config.lootNpcs();
 			lootNpcs = s != null ? Text.fromCSV(s) : Collections.emptyList();
+		}
+		/**
+		 * Used to check if the given webhook is valid.
+		 * If not: notify user.
+		 */
+		if (configChanged.getKey().equals("webhook")) {
+			if(!validateWebHook()) {
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Clan notification webhook is invalid or unreachable", null);
+			}
 		}
 	}
 
@@ -139,6 +153,63 @@ public class DiscordLootLoggerPlugin extends Plugin
 		}
 
 		processLoot(lootReceived.getName(), lootReceived.getItems());
+	}
+
+	/**
+	 * Check if the incoming message should be processed for clan drop notifications
+	 * @param chatMessage
+	 */
+	@Subscribe(priority = 1)
+	public void onChatMessage(ChatMessage chatMessage) {
+
+		// Return if disabled
+		if(!config.enableClanDrops()) return;
+
+		// Return if it is not of the type clan message
+		if(chatMessage.getType() != ChatMessageType.FRIENDSCHAT) {
+			return;
+		}
+		String messageContent = chatMessage.getMessage();
+
+		// Only parse clan drops and pets
+		if(!(messageContent.contains("received") || messageContent.contains("funny feeling") || messageContent.contains("sneaking into your backpack"))) {
+			return;
+		}
+
+		String playerName = Text.sanitize(getPlayerName());
+
+
+		// Only process if in the users name
+		boolean isTarget = Text.sanitize(messageContent).contains(playerName);
+		if(!isTarget) return;
+
+		processClanDrop(messageContent);
+	}
+
+	/**
+	 * Method for processing clan drops.
+	 * @param message the message to post in the discord
+	 */
+	private void processClanDrop(String message) {
+		WebhookBody webhookBody = new WebhookBody();
+		StringBuilder stringBuilder = new StringBuilder();
+		if(config.autoMessageEnabled()) {
+			if(config.autoMessageDate()) {
+				SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+				Date date = new Date();
+				stringBuilder.append(formatter.format(date));
+				stringBuilder.append(" ");
+
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "Discord Loot Logger", formatter.format(date) + " " + config.autoMessage(), null);
+			}
+			else {
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "Discord Loot Logger", config.autoMessage(), null);
+			}
+		}
+		stringBuilder.append(message);
+		webhookBody.setContent(stringBuilder.toString());
+		sendWebhook(webhookBody);
+
 	}
 
 	private String getPlayerName()
@@ -298,4 +369,62 @@ public class DiscordLootLoggerPlugin extends Plugin
 
 		return list;
 	}
+
+	private static String format(Date date)
+	{
+		synchronized (TIME_FORMAT)
+		{
+			return TIME_FORMAT.format(date);
+		}
+	}
+
+	/**
+	 * Method for validating the given webhook provided in the config by the user.
+	 * @return
+	 */
+	private boolean validateWebHook() {
+		if (config.webhook().isEmpty()) return false;
+		if (!urlValidator(config.webhook())) return false;
+		return urlResponseValidator(config.webhook());
+	}
+
+	/**
+	 * Method for validating the URL of the webhook.
+	 * @param url Input url from the config.
+	 * @return return true if the url is valid. False otherwise.
+	 */
+	private boolean urlValidator(String url)
+	{
+		try {
+			new URL(url).toURI();
+			return true;
+		}
+		catch (Exception e) {
+			log.error("Caught error: "+  e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * Method for checking if the given URL is reachable.
+	 * @param url Input url from the config.
+	 * @return return true if the url is reachable. False otherwise.
+	 */
+	private boolean urlResponseValidator(String url) {
+		try {
+			URL validUrl = new URL(url);
+
+			HttpsURLConnection con = (HttpsURLConnection) validUrl.openConnection();
+			con.setRequestMethod("HEAD");
+
+			int responseCode = con.getResponseCode();
+
+			return responseCode == HttpsURLConnection.HTTP_OK;
+		}
+		catch (Exception e) {
+			log.error("Caught error: "+  e.getMessage());
+			return false;
+		}
+	}
+
 }

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -103,15 +103,6 @@ public class DiscordLootLoggerPlugin extends Plugin
 			String s = config.lootNpcs();
 			lootNpcs = s != null ? Text.fromCSV(s) : Collections.emptyList();
 		}
-		/**
-		 * Used to check if the given webhook is valid.
-		 * If not: notify user.
-		 */
-		if (configChanged.getKey().equals("webhook")) {
-			if(!validateWebHook()) {
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Clan notification webhook is invalid or unreachable", null);
-			}
-		}
 	}
 
 	@Subscribe
@@ -368,63 +359,6 @@ public class DiscordLootLoggerPlugin extends Plugin
 		}
 
 		return list;
-	}
-
-	private static String format(Date date)
-	{
-		synchronized (TIME_FORMAT)
-		{
-			return TIME_FORMAT.format(date);
-		}
-	}
-
-	/**
-	 * Method for validating the given webhook provided in the config by the user.
-	 * @return
-	 */
-	private boolean validateWebHook() {
-		if (config.webhook().isEmpty()) return false;
-		if (!urlValidator(config.webhook())) return false;
-		return urlResponseValidator(config.webhook());
-	}
-
-	/**
-	 * Method for validating the URL of the webhook.
-	 * @param url Input url from the config.
-	 * @return return true if the url is valid. False otherwise.
-	 */
-	private boolean urlValidator(String url)
-	{
-		try {
-			new URL(url).toURI();
-			return true;
-		}
-		catch (Exception e) {
-			log.error("Caught error: "+  e.getMessage());
-			return false;
-		}
-	}
-
-	/**
-	 * Method for checking if the given URL is reachable.
-	 * @param url Input url from the config.
-	 * @return return true if the url is reachable. False otherwise.
-	 */
-	private boolean urlResponseValidator(String url) {
-		try {
-			URL validUrl = new URL(url);
-
-			HttpsURLConnection con = (HttpsURLConnection) validUrl.openConnection();
-			con.setRequestMethod("HEAD");
-
-			int responseCode = con.getResponseCode();
-
-			return responseCode == HttpsURLConnection.HTTP_OK;
-		}
-		catch (Exception e) {
-			log.error("Caught error: "+  e.getMessage());
-			return false;
-		}
 	}
 
 }

--- a/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
+++ b/src/main/java/info/sigterm/plugins/discordlootlogger/DiscordLootLoggerPlugin.java
@@ -166,7 +166,7 @@ public class DiscordLootLoggerPlugin extends Plugin
 		if(!config.enableClanDrops()) return;
 
 		// Return if it is not of the type clan message
-		if(chatMessage.getType() != ChatMessageType.FRIENDSCHAT) {
+		if(chatMessage.getType() != ChatMessageType.CLAN_MESSAGE) {
 			return;
 		}
 		String messageContent = chatMessage.getMessage();


### PR DESCRIPTION
# Info
This will add support for webhook integrations for Clan Drop Notifications.

This is a variant of the plugin I tried to add on the Plugin Hub called Clan Drops Webhook, available [here](https://github.com/xncz8h/clandropswebhook)

A moderator of the Plugin Hub repository recommended to merge it with this plugin. For any question I am available add: 
email: xncz8h@gmail.com
discord: Ivo Ko#5306

Will add the Readme of the original repo down below:

# Clan Drops Webhook
##### A plugin for [RuneLite](https://runelite.net/)
A plugin which allows to send a message to your Discord server using a webhook whenever there is a clan broadcast in your name. 

### The webhook is triggered in the following instanced:
* When you receive a drop which is broadcasted to the clan channel. Minimum value for the drop is set by the clan administrators.
* When you receive a pet drop.

### Config options:
* Webhook URL.
* Upload image or text.
* Screenshot only the chatbox instead of the screen.
* Automatically post a message in the chat with or without the current date (useful for bingo phrases).

### TODO:
* Add support for level ups.
* Add support for multiple webhook links for specific channels

#### Contact:
email: xncz8h@gmail.com


