### PR TITLE
timer will no longer reset upon encountering gravestone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.22'
+def runeLiteVersion = '1.8.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/info/sigterm/plugins/deathindicator/DeathIndicatorPlugin.java
+++ b/src/main/java/info/sigterm/plugins/deathindicator/DeathIndicatorPlugin.java
@@ -35,11 +35,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.ItemID;
-import net.runelite.api.MenuAction;
-import net.runelite.api.Tile;
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
@@ -210,7 +206,7 @@ public class DeathIndicatorPlugin extends Plugin
 		{
 			Tile[][][] tiles = client.getScene().getTiles();
 			Tile tile = tiles[client.getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
-			if (tile == null || tile.getGroundItems() == null || tile.getGroundItems().isEmpty())
+			if (tile == null)
 			{
 				reset = true;
 			}


### PR DESCRIPTION
This is a very imperfect fix for the problem a user mentioned in discord; 
```
SuhDude — 11/13/2021
@Adam is this yours? https://i.imgur.com/Pxr616O.png

Adam — 11/13/2021
ya
SuhDude — 11/13/2021
is the timer supposed to disappear once you make it back to your death pile
Adam — 11/13/2021
idr. maybe
its mostly made for uim
SuhDude — 11/13/2021
yea, thats what im using it for haha, but the timer doesnt stay on screen
so it kinda renders it pointless 😅
```
The reason this is messing up is because the new death mechanic removes the death pile and stores it in the grave. The grave need not be on the same tile that the player died. This is a short-term fix to cause the timer to only reset if the death tile is in some unknown area or when the timer actually does reset. 
