### PR TITLE
Empty pouches when leaving Guardians of the Rift

### DIFF
--- a/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
@@ -149,7 +149,6 @@ public class EssPouchPlugin extends Plugin
 		{
 			return;
 		}
-		log.info(event.getMessage());
 		// Clear pouches when GotR starts.
 		if (GOTR_START_MESSAGE.matcher(event.getMessage()).matches())
 		{


### PR DESCRIPTION
Guardian essence is cleared from your pouches when a Guardians of the Rift game begins, or when you leave the Guardians of the Rift minigame. This PR watches chat for the "rift becomes active" message you get when a game starts. Next inventory update, if the GotR widget is not loaded, it clears your pouches.

Also fixes a small typo, "eightteen" --> "eighteen".