### PR TITLE
Add detached camera hotkey

### DIFF
--- a/src/main/java/info/sigterm/plugins/detachedcamera/DetachedCameraConfig.java
+++ b/src/main/java/info/sigterm/plugins/detachedcamera/DetachedCameraConfig.java
@@ -1,0 +1,21 @@
+package info.sigterm.plugins.detachedcamera;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
+
+@ConfigGroup("detachedcamera")
+public interface DetachedCameraConfig extends Config
+{
+	@ConfigItem(
+		position = 0,
+		keyName = "detachedCameraHotkey",
+		name = "Toggle hotkey",
+		description = "Toggle detached camera on/off with a hotkey (unset to disable)"
+	)
+	default Keybind detachedCameraHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+}

--- a/src/main/java/info/sigterm/plugins/detachedcamera/DetachedCameraPlugin.java
+++ b/src/main/java/info/sigterm/plugins/detachedcamera/DetachedCameraPlugin.java
@@ -24,11 +24,15 @@
  */
 package info.sigterm.plugins.detachedcamera;
 
+import com.google.inject.Provides;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.HotkeyListener;
 
 @Slf4j
 @PluginDescriptor(
@@ -41,17 +45,58 @@ public class DetachedCameraPlugin extends Plugin
 	@Inject
 	private Client client;
 
+	@Inject
+	private DetachedCameraConfig config;
+
+	@Inject
+	private KeyManager keyManager;
+
+	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.detachedCameraHotkey())
+	{
+		@Override
+		public void hotkeyPressed()
+		{
+			boolean cameraDetached = (client.getOculusOrbState() == 1);
+			if (cameraDetached)
+			{
+				attachCamera();
+			}
+			else
+			{
+				detachCamera();
+			}
+		}
+	};
+
 	@Override
 	protected void startUp()
 	{
-		client.setOculusOrbState(1);
-		client.setOculusOrbNormalSpeed(36);
+		keyManager.registerKeyListener(hotkeyListener);
+		detachCamera();
 	}
 
 	@Override
 	protected void shutDown()
 	{
+		keyManager.unregisterKeyListener(hotkeyListener);
+		attachCamera();
+	}
+
+	private void detachCamera()
+	{
+		client.setOculusOrbState(1);
+		client.setOculusOrbNormalSpeed(36);
+	}
+
+	private void attachCamera()
+	{
 		client.setOculusOrbState(0);
 		client.setOculusOrbNormalSpeed(12);
+	}
+
+	@Provides
+	DetachedCameraConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(DetachedCameraConfig.class);
 	}
 }


### PR DESCRIPTION
Hi Adam,

This pull request adds a configurable hotkey that toggles the detached camera state on/off.
![detached-camera-hotkey-config](https://user-images.githubusercontent.com/121898402/210454183-eabbe501-56f5-4ffb-bd9c-08c8c393de4c.png)

I enjoy fashionscaping and taking screenshots around the game as I play - the plugin is already amazing for doing that but it can be annoying (especially in resizable modes) to have to open up the sidebar, toggle the plugin off and then on again, and re-close the sidebar. A hotkey, which is off by default, makes the task easier. I believe this will also close #8 

This is my first time making a change to a plugin so please let me know if this looks good or if you'd like something to change about it. Thank you in advance!