### PR TITLE
Player outline prayers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id 'java'
-	id 'checkstyle'
 }
 
 repositories {
@@ -11,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.25'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,10 +23,10 @@ dependencies {
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
-group = 'com.playeroutline'
-version = '1.0'
-sourceCompatibility = '1.8'
+group = 'com.example'
+version = '1.0-SNAPSHOT'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/src/main/java/com/playeroutline/PlayerOutlineConfig.java
+++ b/src/main/java/com/playeroutline/PlayerOutlineConfig.java
@@ -25,15 +25,20 @@
 package com.playeroutline;
 
 import java.awt.Color;
-import net.runelite.client.config.Alpha;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Range;
+
+import net.runelite.client.config.*;
 
 @ConfigGroup("playeroutline")
 public interface PlayerOutlineConfig extends Config
 {
+
+	@ConfigSection(
+			name = "Prayer Color Highlight",
+			description = "Changes color of your highlight based on overhead prayer.",
+			position = 3,
+			closedByDefault = true
+	)
+	String colorHighlightSection = "colorHighlight";
 	@Alpha
 	@ConfigItem(
 		keyName = "playerOutlineColor",
@@ -70,4 +75,84 @@ public interface PlayerOutlineConfig extends Config
 	{
 		return 4;
 	}
+
+	@ConfigItem(
+			name = "Enable Overhead Changing",
+			description = "Changes color based on the overhead being prayed",
+			position = 0,
+			keyName = "prayerChanging",
+			section = colorHighlightSection
+	)
+	default boolean prayerChanging()
+	{
+		return false;
+	}
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorMage",
+			name = "Mage Protection Color",
+			description = "The color for the players outline when praying mage protection",
+			position = 1
+	)
+	default Color playerOutlineColorMage()
+	{
+		return new Color(0,0,255,170);
+	}
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorRange",
+			name = "Range Protection Color",
+			description = "The color for the players outline when praying range protection",
+			position = 2
+	)
+	default Color playerOutlineColorRange()
+	{
+		return new Color(0,255,0,170);
+	}
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorMelee",
+			name = "Melee Protection Color",
+			description = "The color for the players outline when praying melee protection",
+			position = 3
+	)
+	default Color playerOutlineMelee()
+	{
+		return new Color(255,0,0,170);
+	}
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorRedemption",
+			name = "Redemption Color",
+			description = "The color for the players outline when praying redemption",
+			position = 4
+	)
+	default Color playerOutlineColorRedemption()
+	{
+		return new Color(0x3D000000, true);
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorSmite",
+			name = "Smite Color",
+			description = "The color for the players outline when praying smite",
+			position = 5
+	)
+	default Color playerOutlineColorSmite()
+	{
+		return new Color(0x3D000000, true);
+	}
+	@Alpha
+	@ConfigItem(
+			keyName = "playerOutlineColorRet",
+			name = "Retribution Color",
+			description = "The color for the players outline when praying retribution",
+			position = 6
+	)
+	default Color playerOutlineColorRet()
+	{
+		return new Color(0x3D000000, true);
+	}
+
 }

--- a/src/main/java/com/playeroutline/PlayerOutlineConfig.java
+++ b/src/main/java/com/playeroutline/PlayerOutlineConfig.java
@@ -92,40 +92,44 @@ public interface PlayerOutlineConfig extends Config
 			keyName = "playerOutlineColorMage",
 			name = "Mage Protection Color",
 			description = "The color for the players outline when praying mage protection",
-			position = 1
+			position = 1,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineColorMage()
 	{
-		return new Color(0,0,255,170);
+		return new Color(0,0,255,90);
 	}
 	@Alpha
 	@ConfigItem(
 			keyName = "playerOutlineColorRange",
 			name = "Range Protection Color",
 			description = "The color for the players outline when praying range protection",
-			position = 2
+			position = 2,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineColorRange()
 	{
-		return new Color(0,255,0,170);
+		return new Color(0,255,0,90);
 	}
 	@Alpha
 	@ConfigItem(
 			keyName = "playerOutlineColorMelee",
 			name = "Melee Protection Color",
 			description = "The color for the players outline when praying melee protection",
-			position = 3
+			position = 3,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineMelee()
 	{
-		return new Color(255,0,0,170);
+		return new Color(255,0,0,90);
 	}
 	@Alpha
 	@ConfigItem(
 			keyName = "playerOutlineColorRedemption",
 			name = "Redemption Color",
 			description = "The color for the players outline when praying redemption",
-			position = 4
+			position = 4,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineColorRedemption()
 	{
@@ -137,7 +141,8 @@ public interface PlayerOutlineConfig extends Config
 			keyName = "playerOutlineColorSmite",
 			name = "Smite Color",
 			description = "The color for the players outline when praying smite",
-			position = 5
+			position = 5,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineColorSmite()
 	{
@@ -148,7 +153,8 @@ public interface PlayerOutlineConfig extends Config
 			keyName = "playerOutlineColorRet",
 			name = "Retribution Color",
 			description = "The color for the players outline when praying retribution",
-			position = 6
+			position = 6,
+			section = colorHighlightSection
 	)
 	default Color playerOutlineColorRet()
 	{

--- a/src/main/java/com/playeroutline/PlayerOutlineOverlay.java
+++ b/src/main/java/com/playeroutline/PlayerOutlineOverlay.java
@@ -57,7 +57,7 @@ public class PlayerOutlineOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		modelOutlineRenderer.drawOutline(client.getLocalPlayer(), config.borderWidth(), config.playerOutlineColor(), config.outlineFeather());
+		modelOutlineRenderer.drawOutline(client.getLocalPlayer(), config.borderWidth(), plugin.getActiveColor(), config.outlineFeather());
 		return null;
 	}
 

--- a/src/main/java/com/playeroutline/PlayerOutlineOverlay.java
+++ b/src/main/java/com/playeroutline/PlayerOutlineOverlay.java
@@ -39,13 +39,15 @@ public class PlayerOutlineOverlay extends Overlay
 
 	private final Client client;
 	private final PlayerOutlineConfig config;
+	private final PlayerOutlinePlugin plugin;
 	private final ModelOutlineRenderer modelOutlineRenderer;
 
 	@Inject
-	public PlayerOutlineOverlay(Client client, PlayerOutlineConfig config, ModelOutlineRenderer modelOutlineRenderer)
+	public PlayerOutlineOverlay(Client client, PlayerOutlineConfig config, ModelOutlineRenderer modelOutlineRenderer, PlayerOutlinePlugin plugin)
 	{
 		this.client = client;
 		this.config = config;
+		this.plugin = plugin;
 		this.modelOutlineRenderer = modelOutlineRenderer;
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);

--- a/src/main/java/com/playeroutline/PlayerOutlinePlugin.java
+++ b/src/main/java/com/playeroutline/PlayerOutlinePlugin.java
@@ -74,6 +74,11 @@ public class PlayerOutlinePlugin extends Plugin {
 			updateColor();
 	}
 
+	public Color getActiveColor()
+	{
+		return activeColor;
+	}
+
 	@Provides
 	PlayerOutlineConfig provideConfig(ConfigManager configManager)
 	{
@@ -83,7 +88,9 @@ public class PlayerOutlinePlugin extends Plugin {
 	void updateColor()
 	{
 		Player p = client.getLocalPlayer();
-		HeadIcon currentOverhead = p.getOverheadIcon();
+		if(p==null)
+			return;
+        HeadIcon currentOverhead = p.getOverheadIcon();
 		if(currentOverhead == null)
 		{
 			activeColor = config.playerOutlineColor();


### PR DESCRIPTION
I wrote an issue asking if I could make this, after no response I just did. Let me know if you need any more changes before pushing to plugin hub. Thanks -Zach

Added a default off option to change the outline color based upon what overhead is being prayed.
Ideal for content where you have self 2d disabled with entity hider, but still want to know which overhead you are praying.