### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img height="150" src="https://i.imgur.com/X2AmKqW.png"/>
 
-# Player Outline [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/neilrush/Player-Outline/Java%20CI/master?logo=github)](https://github.com/neilrush/Player-Outline/actions) [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/neilrush/Player-Outline?include_prereleases&logo=github)](https://github.com/neilrush/Player-Outline/releases) [![Plugin Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/Player-Outline)](https://runelite.net/plugin-hub/neilrush)
+# Player Outline [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/neilrush/Player-Outline/Java%20CI/master?logo=github)](https://github.com/neilrush/Player-Outline/actions) [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/neilrush/Player-Outline?include_prereleases&logo=github)](https://github.com/neilrush/Player-Outline/releases) [![Plugin Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/player-outline)](https://runelite.net/plugin-hub/neilrush)
 
 <p>A simple plugin that outlines the player allowing you to see the player behind objects.</p>
 <p>A better alternative to a tile indicator because the default outline color makes it hardly noticeable when looking 


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/player-outline) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: