### PR TITLE
Increase max faces FacePrioritySorter

### DIFF
--- a/src/main/java/info/sigterm/plugins/gpuzbuf/FacePrioritySorter.java
+++ b/src/main/java/info/sigterm/plugins/gpuzbuf/FacePrioritySorter.java
@@ -62,7 +62,7 @@ class FacePrioritySorter
 	{
 		distances = new int[MAX_VERTEX_COUNT];
 		distanceFaceCount = new char[MAX_DIAMETER];
-		distanceToFaces = new char[MAX_DIAMETER][512];
+		distanceToFaces = new char[MAX_DIAMETER][700];
 
 		modelCanvasX = new float[MAX_VERTEX_COUNT];
 		modelCanvasY = new float[MAX_VERTEX_COUNT];


### PR DESCRIPTION
Explorer Ring teleport animation has 693 faces, 512 isn't enough and causes a crash due to index OOB.