### PR TITLE
Updated essence pouch limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.3'
+def runeLiteVersion = '1.10.46.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
@@ -383,7 +383,7 @@ public class EssPouchPlugin extends Plugin
 			return;
 		}
 
-		final Pouch pouch = Pouch.forItem(itemId, client.getRealSkillLevel(Skill.RUNECRAFT));
+		final Pouch pouch = Pouch.forItem(itemId, getRunecraftLevel());
 		if (pouch == null) {
 			return;
 		}

--- a/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java
@@ -31,15 +31,11 @@ import java.util.Deque;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemID;
-import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.*;
+import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetInfo.TO_CHILD;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
@@ -114,6 +110,9 @@ public class EssPouchPlugin extends Plugin
 	@Inject
 	private EssencePouchOverlay essencePouchOverlay;
 
+	@Getter
+	static private int runecraftLevel;
+
 	private final Deque<ClickOperation> clickedItems = new ArrayDeque<>();
 	private final Deque<ClickOperation> checkedPouches = new ArrayDeque<>();
 	private int lastEssence;
@@ -134,6 +133,12 @@ public class EssPouchPlugin extends Plugin
 		}
 
 		lastEssence = lastSpace = -1;
+	}
+
+	@Subscribe
+	private void onGameTick(GameTick event)
+	{
+		runecraftLevel = client.getRealSkillLevel(Skill.RUNECRAFT);
 	}
 
 	@Override
@@ -255,14 +260,14 @@ public class EssPouchPlugin extends Plugin
 				case ItemID.LARGE_POUCH:
 				case ItemID.GIANT_POUCH:
 				case ItemID.COLOSSAL_POUCH:
-					Pouch pouch = Pouch.forItem(item.getId());
+					Pouch pouch = Pouch.forItem(item.getId(), runecraftLevel);
 					pouch.degrade(false);
 					break;
 				case ItemID.MEDIUM_POUCH_5511:
 				case ItemID.LARGE_POUCH_5513:
 				case ItemID.GIANT_POUCH_5515:
 				case ItemID.COLOSSAL_POUCH_26786:
-					pouch = Pouch.forItem(item.getId());
+					pouch = Pouch.forItem(item.getId(), runecraftLevel);
 					pouch.degrade(true);
 					break;
 			}
@@ -343,11 +348,9 @@ public class EssPouchPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onMenuOptionClicked(MenuOptionClicked event)
-	{
+	public void onMenuOptionClicked(MenuOptionClicked event) {
 		int itemId = -1;
-		switch (event.getMenuAction())
-		{
+		switch (event.getMenuAction()) {
 			case ITEM_FIRST_OPTION:
 			case ITEM_SECOND_OPTION:
 			case ITEM_THIRD_OPTION:
@@ -360,17 +363,14 @@ public class EssPouchPlugin extends Plugin
 			case CC_OP_LOW_PRIORITY:
 				int widgetId = event.getWidgetId();
 				Widget widget = client.getWidget(TO_GROUP(widgetId), TO_CHILD(widgetId));
-				if (widget != null)
-				{
+				if (widget != null) {
 					int child = event.getActionParam();
-					if (child == -1)
-					{
+					if (child == -1) {
 						return;
 					}
 
 					widget = widget.getChild(child);
-					if (widget != null)
-					{
+					if (widget != null) {
 						itemId = widget.getItemId();
 					}
 				}
@@ -379,20 +379,17 @@ public class EssPouchPlugin extends Plugin
 				return;
 		}
 
-		if (itemId == -1)
-		{
+		if (itemId == -1) {
 			return;
 		}
 
-		final Pouch pouch = Pouch.forItem(itemId);
-		if (pouch == null)
-		{
+		final Pouch pouch = Pouch.forItem(itemId, client.getRealSkillLevel(Skill.RUNECRAFT));
+		if (pouch == null) {
 			return;
 		}
 
 		final int tick = client.getTickCount() + 3;
-		switch (event.getMenuOption())
-		{
+		switch (event.getMenuOption()) {
 			case "Fill":
 				clickedItems.add(new ClickOperation(pouch, tick, 1));
 				checkedPouches.add(new ClickOperation(pouch, tick, 1));

--- a/src/main/java/info/sigterm/plugins/esspouch/EssencePouchOverlay.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/EssencePouchOverlay.java
@@ -30,6 +30,9 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import javax.inject.Inject;
+
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.ui.overlay.components.TextComponent;
@@ -42,10 +45,14 @@ class EssencePouchOverlay extends WidgetItemOverlay
 		showOnInventory();
 	}
 
+	@Inject
+	private Client client;
+
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
 	{
-		final Pouch pouch = Pouch.forItem(itemId);
+
+		final Pouch pouch = Pouch.forItem(itemId, EssPouchPlugin.getRunecraftLevel());
 		if (pouch == null)
 		{
 			return;

--- a/src/main/java/info/sigterm/plugins/esspouch/Pouch.java
+++ b/src/main/java/info/sigterm/plugins/esspouch/Pouch.java
@@ -29,6 +29,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.ItemID;
+import net.runelite.api.Skill;
+import info.sigterm.plugins.esspouch.EssPouchPlugin;
 
 enum Pouch
 {
@@ -36,7 +38,10 @@ enum Pouch
 	MEDIUM(6, 3),
 	LARGE(9, 7),
 	GIANT(12, 9),
-	COLOSSAL(40, 35);
+	COLOSSAL_LVL_25(8, 6), // -2?
+	COLOSSAL_LVL_50(16,0), // -3?
+	COLOSSAL_LVL_75(27, 23), // -4
+	COLOSSAL_LVL_85(40, 35); // -5
 
 	private final int baseHoldAmount;
 	private final int degradedBaseHoldAmount;
@@ -97,7 +102,7 @@ enum Pouch
 		}
 	}
 
-	static Pouch forItem(int itemId)
+	static Pouch forItem(int itemId, int runecraftLevel)
 	{
 		switch (itemId)
 		{
@@ -115,7 +120,14 @@ enum Pouch
 			case ItemID.COLOSSAL_POUCH:
 			case ItemID.COLOSSAL_POUCH_26786:
 			case ItemID.COLOSSAL_POUCH_26906:
-				return COLOSSAL;
+				if(runecraftLevel >= 85)
+					return COLOSSAL_LVL_85;
+				else if(runecraftLevel >= 75)
+					return COLOSSAL_LVL_75;
+				else if(runecraftLevel >= 50)
+					return COLOSSAL_LVL_50;
+				else
+					return COLOSSAL_LVL_25;
 			default:
 				return null;
 		}

--- a/src/test/java/info/sigterm/plugins/esspouch/EssPouchPluginTest.java
+++ b/src/test/java/info/sigterm/plugins/esspouch/EssPouchPluginTest.java
@@ -182,11 +182,11 @@ public class EssPouchPluginTest
 	public void testEmptyCorrection()
 	{
 		// At start, we "know" it has 10 essence (even though it actually is empty!)
-		Pouch.COLOSSAL.setHolding(10);
-		Pouch.COLOSSAL.setUnknown(false);
+		Pouch.COLOSSAL_LVL_85.setHolding(10);
+		Pouch.COLOSSAL_LVL_85.setUnknown(false);
 
 		// It should think there's 10 items
-		assertEquals(10, Pouch.COLOSSAL.getHolding());
+		assertEquals(10, Pouch.COLOSSAL_LVL_85.getHolding());
 
 		clickEmptyPouch(ItemID.COLOSSAL_POUCH);
 
@@ -194,25 +194,25 @@ public class EssPouchPluginTest
 		injectGameMessage("There are no guardian essences in this pouch.");
 
 		// It should now think that the pouch is empty
-		assertEquals(0, Pouch.COLOSSAL.getHolding());
+		assertEquals(0, Pouch.COLOSSAL_LVL_85.getHolding());
 	}
 
 	@Test
 	public void testFullCorrection()
 	{
 		// At start, we "know" it has 10 essence (even though it actually is empty!)
-		Pouch.COLOSSAL.setHolding(10);
-		Pouch.COLOSSAL.setUnknown(false);
+		Pouch.COLOSSAL_LVL_85.setHolding(10);
+		Pouch.COLOSSAL_LVL_85.setUnknown(false);
 
 		// It should think there's 10 items
-		assertEquals(10, Pouch.COLOSSAL.getHolding());
+		assertEquals(10, Pouch.COLOSSAL_LVL_85.getHolding());
 
 		clickFillPouch(ItemID.COLOSSAL_POUCH);
 
 		injectGameMessage("You cannot add any more essence to the pouch.");
 
 		// It should now think that the pouch is full
-		assertEquals(40, Pouch.COLOSSAL.getHolding());
+		assertEquals(40, Pouch.COLOSSAL_LVL_85.getHolding());
 	}
 
 	@Test


### PR DESCRIPTION
Utilizes the new colossal pouch limits depending on the Runecraft level of the player, also changes the test build to the latest version of Runelite.

Worth noting that I am not sure if the degraded pouch states are correct for lvl 25 and lvl 50, but I can confirm 75.